### PR TITLE
Login-pageの装飾と関連するvalidationの設定

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,8 @@
 
 @import "modules/user-signup";
 @import "modules/user-edit";
+@import "modules/user-login";
+
 
 @import 'font-awesome-sprockets';
 @import 'font-awesome';

--- a/app/assets/stylesheets/modules/user-login.scss
+++ b/app/assets/stylesheets/modules/user-login.scss
@@ -1,0 +1,38 @@
+.actions {
+  margin: 5%;
+  text-align: center;
+  &__login {
+    &--btn {
+      background-color: white;
+      color: rgb(16, 101, 212);
+      height: 40px;
+      width: 100%;
+      border-radius: 0.5em;
+      margin-bottom: 5%;
+      border: 2px solid rgb(16, 101, 212);
+    }
+  }
+  &__regist {
+    height: 40px;
+    width: 100%;
+    background-color: rgb(16, 101, 212);
+    margin: 2% auto;
+    border: 2px solid rgb(16, 101, 212);
+    border-radius: 1em;
+    &--btn {
+      font-weight: bold;
+      text-decoration: none;
+      color: white;
+      margin: 0 auto;
+      line-height: 40px;
+    }
+  }
+  &__fog-password {
+    margin: 10px auto;
+    &--link {
+      text-decoration: none;
+      color: rgb(16, 101, 212);
+    }
+  }
+}
+

--- a/app/assets/stylesheets/modules/user-signup.scss
+++ b/app/assets/stylesheets/modules/user-signup.scss
@@ -1,12 +1,4 @@
 .wrapper {
-  .header {
-    &__logo {
-      margin: 20px auto;
-      .logo-image {
-
-      }
-    }
-  }
   .container {
     height: 100vh;
     padding: 150px 0 0 0;
@@ -43,12 +35,14 @@
             margin: 5%;
             text-align: center;
             &__btn {
-              height: 40px;
-              width: 60%;
-              background-color: rgb(16, 101, 212);
-              border-radius: 0.5em;
-              color: white;
-              margin-bottom: 5%;
+              &--blue {
+                background-color: rgb(16, 101, 212);
+                color: white;
+                height: 40px;
+                width: 60%;
+                border-radius: 0.5em;
+                margin-bottom: 5%;
+              }
             }
           }
         }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     @posts = Post.all.order(created_at: "DESC")
   end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,8 +1,5 @@
 .wrapper
-  .header
-    .header__logo
-      = link_to root_path do
-        = image_tag "didit.png", size: "150x50", class: "logo-image"
+  = render "/layouts/header"
   .container
     .contents
       %h2.contents__header
@@ -15,7 +12,7 @@
               .label メールアドレス
               = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-field"
             .field
-              .label 新しいパスワード（8文字以上で入力してください）
+              .label 新しいパスワード（8文字以上）
               = f.password_field :password, autocomplete: "new-password", class: "form-field"
             .field
               .label 新しいパスワード（確認用） 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,8 +1,5 @@
 .wrapper
-  .header
-    .header__logo
-      = link_to root_path do
-        = image_tag "didit.png", size: "150x50", class: "logo-image"
+  = render "/layouts/header"
   .container
     .contents
       %h2.contents__header
@@ -18,10 +15,10 @@
               .label メールアドレス
               = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-field", placeholder: "（例）example@didit.com"
             .field
-              .label パスワード（8文字以上で入力してください）
+              .label パスワード（8文字以上）
               = f.password_field :password, autocomplete: "new-password", class: "form-field"
             .field
               .label パスワード（確認用） 
               = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-field"
             .actions
-              = f.submit "登録する", class: "actions__btn"
+              = f.submit "登録する", class: "actions__btn--blue"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,28 @@
-%h2 Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    %br/
     = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.wrapper
+  = render "/layouts/header"
+  .container
+    .contents
+      %h2.contents__header
+        ユーザーログイン
+      .contents__main
+        .contents__main__inner
+          = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+            = render "devise/shared/error_messages", resource: resource
+            .field
+              .label メールアドレス
+              = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-field", placeholder: "（例）example@didit.com"
+            .field
+              .label パスワード（8文字以上）
+              = f.password_field :password, autocomplete: "new-password", class: "form-field"
+            - if devise_mapping.rememberable?
+              .field
+                = f.check_box :remember_me
+                = f.label :remember_me
+            .actions
+              .actions__login
+                = f.submit "ログイン", class: "actions__login--btn"
+              .actions__regist
+                = link_to "新規登録", new_registration_path(resource_name), class: "actions__regist--btn"
+              .actions__fog-password
+                = link_to "パスワードを忘れた方はこちら", new_password_path(resource_name), class: "actions__fog-password--link"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,3 @@
-    = f.password_field :password, autocomplete: "current-password"
 .wrapper
   = render "/layouts/header"
   .container
@@ -14,7 +13,7 @@
               = f.email_field :email, autofocus: true, autocomplete: "email", class: "form-field", placeholder: "（例）example@didit.com"
             .field
               .label パスワード（8文字以上）
-              = f.password_field :password, autocomplete: "new-password", class: "form-field"
+              = f.password_field :password, autocomplete: "current-password", class: "form-field"
             - if devise_mapping.rememberable?
               .field
                 = f.check_box :remember_me


### PR DESCRIPTION
## What
・Login-pageの装飾
・Loginしていない状況での操作制限の設定

## Why
・Login-pageがdevise導入時のままで、見た目および使い勝手が悪いため
・また、Loginしていない状態での投稿や詳細ページ遷移などを制限するため